### PR TITLE
feat: Sort imports

### DIFF
--- a/packages/eslint-config-datacamp/index.js
+++ b/packages/eslint-config-datacamp/index.js
@@ -29,7 +29,13 @@ module.exports = {
     ecmaVersion: 2019,
     sourceType: 'module',
   },
-  plugins: ['json', 'sort-keys-fix', 'react', 'react-hooks'],
+  plugins: [
+    'json',
+    'react',
+    'react-hooks',
+    'simple-import-sort',
+    'sort-keys-fix',
+  ],
   rules: {
     'comma-dangle': ['error', 'always-multiline'],
     'import/no-extraneous-dependencies': [
@@ -53,6 +59,25 @@ module.exports = {
     'react/jsx-sort-props': 'error',
     'react-hooks/exhaustive-deps': 'error',
     'react-hooks/rules-of-hooks': 'error',
+    'simple-import-sort/sort': [
+      'error',
+      {
+        groups: [
+          // Side effect imports.
+          ['^\\u0000'],
+          // NodeJS modules
+          [`^(${require('module').builtinModules.join('|')})(/|$)`], // eslint-disable-line global-require
+          // Packages
+          ['^@?\\w'],
+          // Absolute imports
+          ['^(src|app)/'],
+          // Relative imports (outside local folder)
+          ['^\\.{2}/'],
+          // Relative imports (inside local folder)
+          ['^\\.{1}/'],
+        ],
+      },
+    ],
     'sort-keys-fix/sort-keys-fix': ['error', 'asc', { natural: true }],
     'sort-order': 'off',
   },

--- a/packages/eslint-config-datacamp/package.json
+++ b/packages/eslint-config-datacamp/package.json
@@ -15,6 +15,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^2.2.0",
+    "eslint-plugin-simple-import-sort": "^5.0.0",
     "eslint-plugin-sort-keys-fix": "^1.0.1",
     "eslint-plugin-typescript-sort-keys": "^0.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2136,6 +2136,11 @@ eslint-plugin-react@^7.16.0:
     prop-types "^15.7.2"
     resolve "^1.12.0"
 
+eslint-plugin-simple-import-sort@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-5.0.0.tgz#fd2abac52c0ae6050baf340c004b0b5d9aa76e8e"
+  integrity sha512-Zn6OppySnbwl/UonkzmMBbiFXZwe/tI9ZlSXwQek5h1FfPv3hcDTE3kG0SC70pBsKuVE8IMwZCMl0tKwcY89rw==
+
 eslint-plugin-sort-keys-fix@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-sort-keys-fix/-/eslint-plugin-sort-keys-fix-1.0.1.tgz#b80422c643df16e8a662b3e22e1cbc1138fa64fa"


### PR DESCRIPTION
Final part of #3: Sorting imports.

This PR will sort imports and group them as follows:

- Side-effect imports (These will be unsorted, they will just group at the top)
- NodeJS imports (stream, http, fs, path, ...)
- package imports (e.g. koa, ...)
- absolute imports (imports starting with `src/` or `app/`
- relative imports outside of the folder `../`
- relative imports inside of the folder `./`

After every group there will be an empty line. I guess the major potential problems could be:
- Should we split out NodeJS deps? I'd say yes because otherwise you might look for them on npm, if you don't know it's a native module
- Should we keep devDeps and deps together (mostly in tests): this plugin doesn't allow splitting => we have to
- Should we split out local imports: We can group them if we want, it just looked as a nice feature. It can help with indicating that you are requiring a lot of "external" files which should probably not happen if you structure your app right