### PR TITLE
feat: sort properties case insentive

### DIFF
--- a/packages/eslint-config-datacamp/index.js
+++ b/packages/eslint-config-datacamp/index.js
@@ -81,7 +81,11 @@ module.exports = {
         ],
       },
     ],
-    'sort-keys-fix/sort-keys-fix': ['error', 'asc', { natural: true }],
+    'sort-keys-fix/sort-keys-fix': [
+      'error',
+      'asc',
+      { natural: true, caseSensitive: false },
+    ],
     'sort-order': 'off',
   },
 };

--- a/packages/eslint-config-datacamp/typescript.js
+++ b/packages/eslint-config-datacamp/typescript.js
@@ -26,7 +26,7 @@ module.exports = {
       },
     ],
     'react/prop-types': 'off',
-    'typescript-sort-keys/interface': ['error', 'asc', { natural: true }],
-    'typescript-sort-keys/string-enum': ['error', 'asc', { natural: true }],
+    'typescript-sort-keys/interface': ['error', 'asc', { natural: true, caseSensitive: false }],
+    'typescript-sort-keys/string-enum': ['error', 'asc', { natural: true, caseSensitive: false }],
   },
 };


### PR DESCRIPTION
BREAKING CHANGE: Sorting of keys and enums is no longer case sensitive.