### PR TITLE
fix(prettier): remove default settings

### DIFF
--- a/packages/prettier-config-datacamp/index.js
+++ b/packages/prettier-config-datacamp/index.js
@@ -1,18 +1,10 @@
 module.exports = {
-  arrowParens: 'avoid',
-  bracketSpacing: true,
-  jsxBracketSameLine: false,
   overrides: [
     {
       files: ['*.json'],
       options: { parser: 'json' },
     },
   ],
-  printWidth: 80,
-  proseWrap: 'preserve',
-  semi: true,
   singleQuote: true,
-  tabWidth: 2,
   trailingComma: 'all',
-  useTabs: false,
 };


### PR DESCRIPTION
The reasoning behind this is that prettier changed some defaults with prettier 2.x but we hardcoded them so we don't get the new `arrowParens` value. Given the goal is to try to stay as close as possible to the community standard, the consensus seems to be to undo these changes.

For people who upgraded prettier already to 2.x, this will be a "breaking" change as it will change the value of `arrowParens`, I'm not sure if it should be marked as such though (currently I didn't)

See also https://datacamp.slack.com/archives/C7Q1W9E05/p1585123587001300