### PR TITLE
fix(prettier): bump version number

### DIFF
--- a/packages/prettier-config-datacamp/package.json
+++ b/packages/prettier-config-datacamp/package.json
@@ -1,11 +1,8 @@
 {
   "name": "@datacamp/prettier-config",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "index.js",
-  "files": [
-    "*.js",
-    "CHANGELOG.md"
-  ],
+  "files": ["*.js", "CHANGELOG.md"],
   "peerDependencies": {
     "prettier": "^1.18.2"
   },


### PR DESCRIPTION
BREAKING CHANGE:
If you already upgraded to prettier 2.x, some settings will have a new value
e.g. `arrowParens` will now have the value `always` instead of `avoid`

I accidentally didn't push the `BREAKING CHANGE` commit in https://github.com/datacamp-engineering/jsconfig/pull/110 so I'm bumping the version number now.