### PR TITLE
fix(eslintrc): do not require function return annotation

### DIFF
--- a/packages/eslint-config-datacamp/package.json
+++ b/packages/eslint-config-datacamp/package.json
@@ -2,12 +2,9 @@
   "name": "@datacamp/eslint-config",
   "version": "1.1.0",
   "main": "index.js",
-  "files": [
-    "*.js",
-    "CHANGELOG.md"
-  ],
+  "files": ["*.js", "CHANGELOG.md"],
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.9.0",
+    "@typescript-eslint/eslint-plugin": "^2.31.0",
     "@typescript-eslint/parser": "^2.9.0",
     "babel-eslint": "^10.0.2",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/eslint-config-datacamp/typescript.js
+++ b/packages/eslint-config-datacamp/typescript.js
@@ -1,5 +1,3 @@
-const { testFilesGlobPatterns } = require('./helpers');
-
 module.exports = {
   extends: [
     './index',
@@ -7,24 +5,9 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'prettier/@typescript-eslint',
   ],
-  overrides: [
-    {
-      files: [...testFilesGlobPatterns, '*.js', '*.jsx'],
-      rules: {
-        '@typescript-eslint/explicit-function-return-type': 'off',
-      },
-    },
-  ],
   plugins: ['json', 'typescript-sort-keys'],
   rules: {
-    '@typescript-eslint/explicit-function-return-type': [
-      'error',
-      {
-        allowExpressions: true,
-        allowHigherOrderFunctions: true,
-        allowTypedFunctionExpressions: true,
-      },
-    ],
+    '@typescript-eslint/explicit-function-return-type': 'off',
     'import/extensions': [
       'error',
       'ignorePackages',


### PR DESCRIPTION
See also https://datacamp.slack.com/archives/C7Q1W9E05/p1588177457004500

From my experience in multiplexer:
* I've had to annotate simple functions that typescript can easily infer, so it becomes slower
* The code often becomes ugly and verbose (quite often the return type is also just what makes prettier wrap the line)

I know this is a contested one but in my opinion, this will bring more productivity and the chance on bugs is low as the callsite you will notice in 99% of all cases that something is wrong with the return type and you can then either type it or fix your bug so typescript infers the type correctly.