### PR TITLE
Add sonar-lint

### DIFF
--- a/packages/eslint-config-datacamp/index.js
+++ b/packages/eslint-config-datacamp/index.js
@@ -9,6 +9,7 @@ module.exports = {
     'plugin:prettier/recommended',
     'prettier',
     'prettier/react',
+    'plugin:sonarjs/recommended',
   ],
   overrides: [
     {
@@ -16,6 +17,9 @@ module.exports = {
         jest: true,
       },
       files: testFilesGlobPatterns,
+      rules: {
+        'sonarjs/no-identical-functions': 'off',
+      },
     },
     {
       files: ['prettier.config.js'],
@@ -35,6 +39,7 @@ module.exports = {
     'react',
     'react-hooks',
     'simple-import-sort',
+    'sonarjs',
     'sort-keys-fix',
     'eslint-comments',
   ],
@@ -84,6 +89,10 @@ module.exports = {
         ],
       },
     ],
+    'sonarjs/cognitive-complexity': 'warn',
+    'sonarjs/max-switch-cases': 'off',
+    'sonarjs/no-duplicate-string': 'warn',
+    'sonarjs/no-small-switch': 'off',
     'sort-keys-fix/sort-keys-fix': [
       'error',
       'asc',

--- a/packages/eslint-config-datacamp/package.json
+++ b/packages/eslint-config-datacamp/package.json
@@ -2,10 +2,7 @@
   "name": "@datacamp/eslint-config",
   "version": "2.0.0",
   "main": "index.js",
-  "files": [
-    "*.js",
-    "CHANGELOG.md"
-  ],
+  "files": ["*.js", "CHANGELOG.md"],
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.1",
@@ -20,6 +17,7 @@
     "eslint-plugin-react": "^7.20.5",
     "eslint-plugin-react-hooks": "^4.0.0",
     "eslint-plugin-simple-import-sort": "^5.0.0",
+    "eslint-plugin-sonarjs": "^0.5.0",
     "eslint-plugin-sort-keys-fix": "^1.0.1",
     "eslint-plugin-typescript-sort-keys": "^1.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2595,6 +2595,11 @@ eslint-plugin-simple-import-sort@^5.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-5.0.3.tgz#9ae258ddada6efffc55e47a134afbd279eb31fc6"
   integrity sha512-1rf3AWiHeWNCQdAq0iXNnlccnH1UDnelGgrPbjBBHE8d2hXVtOudcmy0vTF4hri3iJ0MKz8jBhmH6lJ0ZWZLHQ==
 
+eslint-plugin-sonarjs@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.5.0.tgz#ce17b2daba65a874c2862213a9e38e8986ad7d7d"
+  integrity sha512-XW5MnzlRjhXpIdbULC/qAdJYHWw3rRLws/DyawdlPU/IdVr9AmRK1r2LaCvabwKOAW2XYYSo3kDX58E4MrB7PQ==
+
 eslint-plugin-sort-keys-fix@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-sort-keys-fix/-/eslint-plugin-sort-keys-fix-1.1.1.tgz#2ed201b53fd4a89552c6e2abd38933f330a4b62e"


### PR DESCRIPTION
Add [sonarlint](https://www.sonarlint.org/) plugin with 2 changes to the default config:
### sonarjs/cognitive-complexity
This is an alternative implementation to cyclomatic complexity, I think it’s very useful but we can’t fail the linter there in old projects because you would need to refactor a lot…
### sonarjs/no-duplicate-string
This one is also very valuable and I did some refactors based on it but it’s pretty strict. It also warns when using `border-box` 3 times in a file but of course putting a CSS variable in a constant does not make a lot of sense IMO. I also opened an issue about this: https://github.com/SonarSource/eslint-plugin-sonarjs/issues/173