### PR TITLE
chore: automerge dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,3 +3,8 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "weekly"
+    version_requirement_updates: "increase_versions"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "semver:minor"


### PR DESCRIPTION
As discussed during the sync, this will allow dependabot to automatically merge some dependencies, whilst also bumping the version number to keep in sync with the lockfile