### PR TITLE
feat: add eslint-plugin-comments

### DIFF
--- a/packages/eslint-config-datacamp/index.js
+++ b/packages/eslint-config-datacamp/index.js
@@ -36,9 +36,12 @@ module.exports = {
     'react-hooks',
     'simple-import-sort',
     'sort-keys-fix',
+    'eslint-comments',
   ],
   rules: {
     'comma-dangle': 'off', // Defined by prettier
+    'eslint-comments/no-unused-disable': 'error',
+    'eslint-comments/no-unused-enable': 'error',
     'import/no-extraneous-dependencies': [
       'error',
       {

--- a/packages/eslint-config-datacamp/package.json
+++ b/packages/eslint-config-datacamp/package.json
@@ -12,6 +12,7 @@
     "babel-eslint": "^10.0.2",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.0.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jest": "^23.0.5",
     "eslint-plugin-json": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2519,6 +2519,14 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
+eslint-plugin-eslint-comments@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz#9e1cd7b4413526abb313933071d7aba05ca12ffa"
+  integrity sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 eslint-plugin-import@^2.22.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"
@@ -3398,6 +3406,11 @@ ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.0.5:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
 import-fresh@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Falls under _correctness_

This plugin will report unused eslint suppression comments. These gradually build up over time and add fluff to a codebase. This rule is particularly useful for migrating from an existing eslint config where different rules may have been suppressed that are no longer present

How are we doing versioning..?