### PR TITLE
chore: Allow infinitly long lines in the body of a commit message

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [2, 'always', Infinity],
+  },
 };


### PR DESCRIPTION
Otherwise dependabot PRs fail sometimes. See https://app.circleci.com/pipelines/github/datacamp-engineering/jsconfig/298/workflows/ca04ca42-061c-4885-b7b6-6da80e05fa57/jobs/188 for an example failure