### PR TITLE
feat(eslint): add array-type rule

### DIFF
--- a/packages/eslint-config-datacamp/typescript.js
+++ b/packages/eslint-config-datacamp/typescript.js
@@ -25,6 +25,7 @@ module.exports = {
   ],
   plugins: ['json', 'typescript-sort-keys'],
   rules: {
+    '@typescript-eslint/array-type': 'array-simple',
     '@typescript-eslint/explicit-function-return-type': [
       'error',
       {


### PR DESCRIPTION
This falls under Vision Value 1: *Consistency*

Typescript allows both `Array<string>` and `string[]`.
This eslint rule would format it as `string[]` but if it's a complex type it becomes `Array<{ foo: number}>`

The idea behind this setting was that in general the `Array<>` syntax is more verbose and thus a bit harder
to parse (especially if it starts wrapping lines, it can be really annoying)

E.g. compare
```typescript
const foo = ({
  x
}: FooArgs): Array<string}> => {
  return [{foobar: x, type: 'foobarnumber'}]
}
```
vs
```typescript
const foo = ({x}: FooArgs): string[] => {
  return [{foobar: x, type: 'foobarnumber'}]
}
```

On the other hand, sometimes we have multiline block definitions + array and then the array is really hard to find where it started. E.g. compare:
```typescript
const foo = (x: number): Array<{
  foobar: number,
  type: 'foobarnumber'
}> => {
  return [{foobar: x, type: 'foobarnumber'}]
}
```
vs
```typescript
const foo = (x: number): {
  foobar: number,
  type: 'foobarnumber'
}[] => {
  return [{foobar: x, type: 'foobarnumber'}]
}
```

As discussed on Slack (https://datacamp.slack.com/archives/C7Q1W9E05/p1597160310002600)