### PR TITLE
chore: update README to include tsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ module.exports = {
 Afterwards you can run eslint as follows:
 
 ```bash
-yarn eslint . --ext ts,js,json --ignore-path .gitignore
+yarn eslint . --ext ts,tsx,js,json --ignore-path .gitignore
 ```
 
 It's recommended to:


### PR DESCRIPTION
This PR updates the example lint command to also include `*.tsx` files.