### PR TITLE
Minor rules update

### DIFF
--- a/packages/eslint-config-datacamp/index.js
+++ b/packages/eslint-config-datacamp/index.js
@@ -50,7 +50,7 @@ module.exports = {
     'comma-dangle': 'off', // Defined by prettier
     'eslint-comments/no-unused-disable': 'error',
     'eslint-comments/no-unused-enable': 'error',
-    'filenames/match-exported': ['error', [null, 'camel'], null, true],
+    'filenames/match-exported': ['error', [null, 'camel', 'kebab'], null, true],
     'import/no-anonymous-default-export': ['error', { allowObject: true }],
     'import/no-extraneous-dependencies': [
       'error',

--- a/packages/eslint-config-datacamp/index.js
+++ b/packages/eslint-config-datacamp/index.js
@@ -73,6 +73,7 @@ module.exports = {
     'jest/no-deprecated-functions': 'off', // Needs to know the jest version, not possible from a shared config
     'max-classes-per-file': 'off',
     'no-console': 'error',
+    'no-plusplus': 'off',
     'no-useless-catch': 'error',
     'no-useless-constructor': 'off',
     'object-shorthand': ['error', 'always'],

--- a/packages/eslint-config-datacamp/index.js
+++ b/packages/eslint-config-datacamp/index.js
@@ -52,6 +52,7 @@ module.exports = {
     'eslint-comments/no-unused-enable': 'error',
     'filenames/match-exported': ['error', [null, 'camel', 'kebab'], null, true],
     'import/no-anonymous-default-export': ['error', { allowObject: true }],
+    'import/no-deprecated': 'warn',
     'import/no-extraneous-dependencies': [
       'error',
       {


### PR DESCRIPTION
Updated added following rules:

- allow kebab case in `filenames/match-exported`
- allow usage of unary operators by turning off `no-plusplus`
- warn about deprecated module exports with `import/no-deprecated`