### PR TITLE
chore: update eslint version that needs to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The goal of JS Config is to improve the productivity of our developers (in the l
 ### ESlint :wrench:
 
 ```bash
-yarn add -D eslint @datacamp/eslint-config
+yarn add -D eslint@^7.0.0 @datacamp/eslint-config
 ```
 
 Create a file `.eslintrc.js` with the following contents


### PR DESCRIPTION
## Description

While setting up jsconfig in the new `competitions-content` repo we faced an issue related to jest plugin version installed along. Using the v7 specifically solved the issue.